### PR TITLE
[chore] fix linter errors and warnings

### DIFF
--- a/components/AboutCairoVMBanner.tsx
+++ b/components/AboutCairoVMBanner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from 'react'
+import { useState, useEffect } from 'react'
 
 import { RiCloseLine } from '@remixicon/react'
 
@@ -14,8 +14,6 @@ const AboutCairoVMBanner = () => {
   }, [])
 
   const handleCloseBanner = () => {
-    // Save the state in local storage to prevent the banner from showing again
-    // localStorage.setItem('isBannerClosed', 'true')
     setIsShown(false)
   }
 

--- a/components/ChainSelector.tsx
+++ b/components/ChainSelector.tsx
@@ -99,8 +99,6 @@ const ChainSelector = () => {
     <div className="flex justify-end items-center rounded">
       {forks.length > 0 && (
         <div className="flex items-center mr-2">
-          {/* <Icon name="git-branch-line" className="text-indigo-500 mr-2" /> */}
-
           <Select
             onChange={handleForkChange}
             options={forkOptions}

--- a/components/Editor/ExecutionStatus.tsx
+++ b/components/Editor/ExecutionStatus.tsx
@@ -1,14 +1,13 @@
 import { useContext } from 'react'
 
 import { useRegisterActions } from 'kbar'
-import ReactTooltip from 'react-tooltip'
 
 import { EthereumContext } from 'context/ethereumContext'
 
 import { Button } from 'components/ui'
 
 const ExecutionStatus = () => {
-  const { isExecuting, executionState, nextExecution, continueExecution } =
+  const { isExecuting, nextExecution, continueExecution } =
     useContext(EthereumContext)
 
   const actions = [

--- a/components/Editor/Header.tsx
+++ b/components/Editor/Header.tsx
@@ -1,10 +1,6 @@
-import { useContext, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import Select, { OnChangeValue } from 'react-select'
-
-import { EthereumContext } from 'context/ethereumContext'
-
-import { Label } from 'components/ui'
 
 import { CodeType } from './types'
 
@@ -19,8 +15,6 @@ const codeLangOptions = Object.keys(CodeType).map((lang) => ({
 }))
 
 const EditorHeader = ({ codeType, onCodeTypeChange }: Props) => {
-  const { selectedFork } = useContext(EthereumContext)
-
   const codeTypeValue = useMemo(
     () => ({
       value: codeType,

--- a/components/Editor/Instructions.tsx
+++ b/components/Editor/Instructions.tsx
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useRef, RefObject, createRef, Ref } from 'react'
 
-import { CairoVMApiContext } from 'context/cairoVMApiContext'
 import { EthereumContext } from 'context/ethereumContext'
 
 import InstructionRow from './InstructionRow'

--- a/components/Editor/Instructions.tsx
+++ b/components/Editor/Instructions.tsx
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useRef, RefObject, createRef, Ref } from 'react'
 
+import { CairoVMApiContext } from 'context/cairoVMApiContext'
 import { EthereumContext } from 'context/ethereumContext'
 
 import InstructionRow from './InstructionRow'
-import { CairoVMApiContext } from 'context/cairoVMApiContext'
 
 type TableProps = {
   containerRef: RefObject<HTMLDivElement>

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -5,39 +5,22 @@ import React, {
   useContext,
   useMemo,
   useCallback,
-  MutableRefObject,
   RefObject,
   Fragment,
 } from 'react'
 
-import { bufferToHex } from '@ethereumjs/util'
 import { encode, decode } from '@kunigi/string-compression'
 import { RiLinksLine } from '@remixicon/react'
 import cn from 'classnames'
 import copy from 'copy-to-clipboard'
 import { useRouter } from 'next/router'
-import { OnChangeValue } from 'react-select'
 import SCEditor from 'react-simple-code-editor'
 
 import { CairoVMApiContext, CompilationState } from 'context/cairoVMApiContext'
-import { EthereumContext } from 'context/ethereumContext'
 import { SettingsContext, Setting } from 'context/settingsContext'
 
 import { getAbsoluteURL } from 'util/browser'
-import {
-  getTargetEvmVersion,
-  compilerSemVer,
-  getBytecodeFromMnemonic,
-  getMnemonicFromBytecode,
-  getBytecodeLinesFromInstructions,
-} from 'util/compiler'
-import {
-  codeHighlight,
-  isEmpty,
-  isFullHex,
-  isHex,
-  objToQueryString,
-} from 'util/string'
+import { codeHighlight, isEmpty, objToQueryString } from 'util/string'
 
 import examples from 'components/Editor/examples'
 import { Tracer } from 'components/Tracer'
@@ -45,9 +28,8 @@ import { Button } from 'components/ui'
 
 import Console from './Console'
 import Header from './Header'
-import Instructions from './Instructions'
 import { InstructionsTable } from './InstructionsTable'
-import { IConsoleOutput, CodeType, ValueUnit, Contract } from './types'
+import { IConsoleOutput, CodeType } from './types'
 
 type Props = {
   readOnly?: boolean
@@ -59,22 +41,11 @@ type SCEditorRef = {
 
 const cairoEditorHeight = 350
 const runBarHeight = 52
-const sierraEditorHeight = cairoEditorHeight + runBarHeight
-const casmInstructionsListHeight = cairoEditorHeight + runBarHeight
-const instructionsListWithExpandHeight = cairoEditorHeight + 156 // Advance Mode bar
 const consoleHeight = 150
 
 const Editor = ({ readOnly = false }: Props) => {
-  const { settingsLoaded, getSetting, setSetting } = useContext(SettingsContext)
+  const { settingsLoaded, getSetting } = useContext(SettingsContext)
   const router = useRouter()
-
-  // const {
-  //   deployedContractAddress,
-  //   selectedFork,
-  //   opcodes,
-  //   instructions,
-  //   onForkChange,
-  // } = useContext(EthereumContext)
 
   const {
     sierraCode,
@@ -90,21 +61,13 @@ const Editor = ({ readOnly = false }: Props) => {
 
   const [cairoCode, setCairoCode] = useState('')
   const [codeType, setCodeType] = useState<string | undefined>()
-  const [cairoCodeModified, setCairoCodeModified] = useState(false)
   const [output, setOutput] = useState<IConsoleOutput[]>([
     {
       type: 'info',
       message: 'App initialised...',
     },
   ])
-  // const solcWorkerRef = useRef<null | Worker>(null)
-  const instructionsRef = useRef() as MutableRefObject<HTMLDivElement>
   const editorRef = useRef<SCEditorRef>()
-  const [callData, setCallData] = useState('')
-  const [callValue, setCallValue] = useState('')
-  const [unit, setUnit] = useState(ValueUnit.Wei as string)
-
-  const [isExpanded, setIsExpanded] = useState(false)
 
   const log = useCallback(
     (line: string, type = 'info') => {
@@ -121,15 +84,6 @@ const Editor = ({ readOnly = false }: Props) => {
   useEffect(() => {
     const query = router.query
 
-    if ('callValue' in query && 'unit' in query) {
-      setCallValue(query.callValue as string)
-      setUnit(query.unit as string)
-    }
-
-    if ('callData' in query) {
-      setCallData(query.callData as string)
-    }
-
     if ('codeType' in query && 'code' in query) {
       setCodeType(query.codeType as string)
       setCairoCode(JSON.parse('{"a":' + decode(query.code as string) + '}').a)
@@ -140,10 +94,6 @@ const Editor = ({ readOnly = false }: Props) => {
       setCodeType(initialCodeType)
       setCairoCode(examples[initialCodeType][0])
     }
-
-    // if ('fork' in query) {
-    //   onForkChange(query.fork as string)
-    // }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsLoaded && router.isReady])
 
@@ -158,18 +108,10 @@ const Editor = ({ readOnly = false }: Props) => {
     } else if (isCompiling === CompilationState.Error) {
       log('Compilation failed: ', 'error')
     }
-  }, [isCompiling])
-
-  // useEffect(() => {
-  //   if (deployedContractAddress) {
-  //     log(`Contract deployed at address: ${deployedContractAddress}`)
-  //   }
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [deployedContractAddress])
+  }, [isCompiling, log, serializedOutput])
 
   const handleCairoCodeChange = (value: string) => {
     setCairoCode(value)
-    setCairoCodeModified(true)
   }
 
   const highlightCode = (value: string) => {
@@ -177,9 +119,6 @@ const Editor = ({ readOnly = false }: Props) => {
       return value
     }
 
-    // if (codeType === CodeType.Bytecode) {
-    //   return codeHighlight(value, codeType).value
-    // }
     let _codeType = codeType
 
     if (_codeType === CodeType.Sierra) {
@@ -198,33 +137,23 @@ const Editor = ({ readOnly = false }: Props) => {
 
   const handleCompileRun = useCallback(() => {
     compileCairoCode(cairoCode)
-  }, [cairoCode])
+  }, [cairoCode, compileCairoCode])
 
   const handleCopyPermalink = useCallback(() => {
-    // const fork = selectedFork?.name
     const params = {
-      // fork,
-      // callValue,
-      // unit,
-      // callData,
       codeType,
       code: encodeURIComponent(encode(JSON.stringify(cairoCode))),
     }
 
     copy(`${getAbsoluteURL('/')}?${objToQueryString(params)}`)
     log('Link with current Cairo code copied to clipboard')
-  }, [cairoCode, log])
+  }, [cairoCode, codeType, log])
 
   const isCompileDisabled = useMemo(() => {
     return isCompiling === CompilationState.Compiling || isEmpty(cairoCode)
   }, [isCompiling, cairoCode])
 
-  // const isBytecode = useMemo(() => codeType === CodeType.Bytecode, [codeType])
   const isBytecode = false
-
-  const showAdvanceMode = useMemo(() => {
-    return codeType === CodeType.Cairo && isExpanded
-  }, [codeType, isExpanded])
 
   return (
     <div className="bg-gray-100 dark:bg-black-700 rounded-lg">
@@ -273,66 +202,35 @@ const Editor = ({ readOnly = false }: Props) => {
             </div>
 
             <Fragment>
-              {!showAdvanceMode && (
-                <div className="flex flex-col md:flex-row md:items-center md:justify-between px-4 py-4 md:py-2 md:border-r border-gray-200 dark:border-black-500">
-                  <div className="flex flex-col md:flex-row md:gap-x-4 gap-y-2 md:gap-y-0 mb-4 md:mb-0">
-                    <Button
-                      onClick={handleCopyPermalink}
-                      transparent
-                      padded={false}
-                      tooltip="Share permalink"
-                      tooltipId="share-permalink"
-                    >
-                      <span className="inline-block mr-4 select-all">
-                        <RiLinksLine
-                          size={16}
-                          className="text-indigo-500 mr-1"
-                        />
-                      </span>
-                    </Button>
-                  </div>
-
-                  <div>
-                    <Button
-                      onClick={handleCompileRun}
-                      disabled={isCompileDisabled}
-                      size="sm"
-                      contentClassName="justify-center"
-                    >
-                      Compile and run
-                    </Button>
-                  </div>
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between px-4 py-4 md:py-2 md:border-r border-gray-200 dark:border-black-500">
+                <div className="flex flex-col md:flex-row md:gap-x-4 gap-y-2 md:gap-y-0 mb-4 md:mb-0">
+                  <Button
+                    onClick={handleCopyPermalink}
+                    transparent
+                    padded={false}
+                    tooltip="Share permalink"
+                    tooltipId="share-permalink"
+                  >
+                    <span className="inline-block mr-4 select-all">
+                      <RiLinksLine size={16} className="text-indigo-500 mr-1" />
+                    </span>
+                  </Button>
                 </div>
-              )}
+
+                <div>
+                  <Button
+                    onClick={handleCompileRun}
+                    disabled={isCompileDisabled}
+                    size="sm"
+                    contentClassName="justify-center"
+                  >
+                    Compile and run
+                  </Button>
+                </div>
+              </div>
             </Fragment>
           </div>
         </div>
-
-        {/* <div className="w-full md:w-1/3">
-          <div className="border-t md:border-t-0 border-b border-gray-200 dark:border-black-500 flex items-center pl-4 pr-6 h-14 md:border-r">
-            <span className="text-gray-600 dark:text-gray-400 text-sm">
-              Sierra
-            </span>
-          </div>
-
-          <div
-            className="pane pane-light overflow-auto md:border-r bg-gray-50 dark:bg-black-600 border-gray-200 dark:border-black-500 h-full"
-            style={{ height: sierraEditorHeight }}
-          >
-            <SCEditor
-              // @ts-ignore: SCEditor is not TS-friendly
-              ref={editorRef}
-              value={sierraCode}
-              readOnly={readOnly}
-              onValueChange={handleCairoCodeChange}
-              highlight={highlightCode}
-              tabSize={4}
-              className={cn('code-editor', {
-                // 'with-numbers': !isBytecode,
-              })}
-            />
-          </div>
-        </div> */}
 
         <div className="w-full md:w-1/2">
           <Tracer
@@ -344,14 +242,6 @@ const Editor = ({ readOnly = false }: Props) => {
       </div>
 
       <div className="flex flex-col md:flex-row-reverse">
-        {/* <div className="w-full md:w-1/2">
-          <div
-            className="pane pane-dark overflow-auto border-t border-black-900/25 bg-gray-800 dark:bg-black-700 text-white px-4 py-3"
-            style={{ height: consoleHeight }}
-          >
-            <ExecutionState />
-          </div>
-        </div> */}
         <div className="w-full">
           <div
             className="pane pane-dark overflow-auto bg-gray-800 dark:bg-black-700 text-white border-t border-black-900/25 md:border-r"

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -12,14 +12,14 @@ import React, {
 
 import { bufferToHex } from '@ethereumjs/util'
 import { encode, decode } from '@kunigi/string-compression'
+import { RiLinksLine } from '@remixicon/react'
 import cn from 'classnames'
 import copy from 'copy-to-clipboard'
 import { useRouter } from 'next/router'
 import { OnChangeValue } from 'react-select'
 import SCEditor from 'react-simple-code-editor'
 
-import { RiLinksLine } from '@remixicon/react'
-
+import { CairoVMApiContext, CompilationState } from 'context/cairoVMApiContext'
 import { EthereumContext } from 'context/ethereumContext'
 import { SettingsContext, Setting } from 'context/settingsContext'
 
@@ -40,15 +40,14 @@ import {
 } from 'util/string'
 
 import examples from 'components/Editor/examples'
+import { Tracer } from 'components/Tracer'
 import { Button } from 'components/ui'
 
 import Console from './Console'
 import Header from './Header'
-import { IConsoleOutput, CodeType, ValueUnit, Contract } from './types'
-import { CairoVMApiContext, CompilationState } from 'context/cairoVMApiContext'
-import { Tracer } from 'components/Tracer'
-import { InstructionsTable } from './InstructionsTable'
 import Instructions from './Instructions'
+import { InstructionsTable } from './InstructionsTable'
+import { IConsoleOutput, CodeType, ValueUnit, Contract } from './types'
 
 type Props = {
   readOnly?: boolean

--- a/components/Editor/types.ts
+++ b/components/Editor/types.ts
@@ -2,8 +2,6 @@ export enum CodeType {
   Cairo = 'Cairo',
   Sierra = 'Sierra',
   CASM = 'CASM',
-  // Bytecode = 'Bytecode',
-  // Mnemonic = 'Mnemonic',
 }
 
 export enum ValueUnit {

--- a/components/Reference/DocRow.tsx
+++ b/components/Reference/DocRow.tsx
@@ -1,13 +1,8 @@
-import { useContext, useMemo, useEffect, useState } from 'react'
-
 import cn from 'classnames'
 import { MDXRemote } from 'next-mdx-remote'
 import { IReferenceItem, IItemDoc, IGasDoc } from 'types'
 
-import { EthereumContext } from 'context/ethereumContext'
-
 import { GITHUB_REPO_URL } from 'util/constants'
-import { parseGasPrices, findMatchingForkName } from 'util/gas'
 
 import * as Doc from 'components/ui/Doc'
 
@@ -35,51 +30,13 @@ const docComponents = {
   pre: Doc.Pre,
 }
 
-const API_DYNAMIC_FEE_DOC_URL = '/api/getDynamicDoc'
-
+// TODO: remove gasDocs in the whole component tree if not used
 const DocRow = ({
   itemDoc,
   referenceItem,
-  gasDocs,
+  gasDocs, // eslint-disable-line @typescript-eslint/no-unused-vars
   dynamicFeeForkName,
 }: Props) => {
-  const { common, forks, selectedFork } = useContext(EthereumContext)
-  const [dynamicFeeDocMdx, setDynamicFeeDocMdx] = useState()
-
-  const dynamicFeeDoc = useMemo(() => {
-    if (!gasDocs) {
-      return null
-    }
-    const fork = findMatchingForkName(forks, Object.keys(gasDocs), selectedFork)
-    return fork && common ? parseGasPrices(common, gasDocs[fork]) : null
-  }, [forks, selectedFork, gasDocs, common])
-
-  useEffect(() => {
-    let controller: AbortController | null = new AbortController()
-
-    const fetchDynamicFeeDoc = async () => {
-      try {
-        const response = await fetch(API_DYNAMIC_FEE_DOC_URL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: dynamicFeeDoc }),
-          signal: controller?.signal,
-        })
-        const data = await response.json()
-        setDynamicFeeDocMdx(data.mdx)
-        controller = null
-      } catch (error) {
-        setDynamicFeeDocMdx(undefined)
-      }
-    }
-
-    if (dynamicFeeDoc) {
-      fetchDynamicFeeDoc()
-    }
-
-    return () => controller?.abort()
-  }, [dynamicFeeDoc])
-
   return (
     <div className="text-sm px-4 md:px-8 py-8 bg-indigo-50 dark:bg-black-600">
       {itemDoc && (
@@ -108,15 +65,6 @@ const DocRow = ({
               })}
             >
               <MDXRemote {...itemDoc.mdxSource} components={docComponents} />
-
-              {/*
-              {dynamicFeeForkName && dynamicFeeDocMdx && (
-                <MDXRemote
-                  compiledSource=""
-                  {...(dynamicFeeDocMdx ? dynamicFeeDocMdx : {})}
-                  components={docComponents as any}
-                />
-              )} */}
             </div>
 
             {dynamicFeeForkName && (

--- a/components/Reference/DynamicFee.tsx
+++ b/components/Reference/DynamicFee.tsx
@@ -151,15 +151,11 @@ const DynamicFee = ({ referenceItem, fork }: Props) => {
         })}
 
         <div className="flex items-center pt-2">
-          {/* <Icon name="gas-station-fill" className="text-indigo-500 mr-2" /> */}
           Static gas + dynamic gas = {gasCost}
         </div>
 
         {canRefund && (
-          <div className="flex items-center pt-2">
-            {/* <Icon name="reply-fill" className="text-indigo-500 mr-2" /> */}
-            Gas refund = {gasRefund}
-          </div>
+          <div className="flex items-center pt-2">Gas refund = {gasRefund}</div>
         )}
       </div>
     </div>

--- a/components/Reference/index.tsx
+++ b/components/Reference/index.tsx
@@ -10,7 +10,6 @@ import {
 
 import cn from 'classnames'
 import useWindowSize from 'lib/useWindowResize'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useTable, useExpanded, useFilters, HeaderGroup } from 'react-table'
 import ReactTooltip from 'react-tooltip'
@@ -131,10 +130,6 @@ const ReferenceTable = ({
           <span className="text-sm font-normal">
             {isAllRowsExpanded ? 'Collapse' : 'Expand'}
           </span>
-          {/* <Icon
-            className="text-indigo-500"
-            name={isAllRowsExpanded ? 'arrow-up-s-line' : 'arrow-down-s-line'}
-          /> */}
         </Button>
       </div>
     )
@@ -243,24 +238,6 @@ const ReferenceTable = ({
                       }}
                     >
                       <div className="flex items-center flex-wrap">
-                        {cell.column.id === 'opcodeOrAddress' && (
-                          <Link
-                            href={
-                              isPrecompiled
-                                ? `/precompiled#${opcodeOrAddress}?fork=${selectedFork?.name}`
-                                : `/#${opcodeOrAddress}?fork=${selectedFork?.name}`
-                            }
-                            passHref
-                            legacyBehavior
-                          >
-                            <a className="underline font-mono">
-                              {/* <Icon
-                                name="links-line"
-                                className="text-indigo-500 mr-2"
-                              /> */}
-                            </a>
-                          </Link>
-                        )}
                         {cell.render('Cell')}
                         {cell.column.id === 'minimumFee' &&
                           !!dynamicFeeForkName && (
@@ -269,7 +246,6 @@ const ReferenceTable = ({
                               data-tip="Has additional dynamic gas cost, expand to estimate it"
                               data-for={`tip-${cell.row.id}`}
                             >
-                              {/* <Icon name="question-line" /> */}
                               <ReactTooltip
                                 className="tooltip"
                                 effect="solid"

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -47,7 +47,6 @@ const ThemeSelector = () => {
       shortcut: ['t'],
       keywords: 'theme appearance',
       section: 'Preferences',
-      // children: ['theme-light', 'theme-dark', 'theme-system'],
     },
   ]
 

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -1,9 +1,8 @@
+import { RiContrast2Fill, RiContrast2Line } from '@remixicon/react'
 import { useRegisterActions, Action } from 'kbar'
 import { useTheme } from 'next-themes'
 
 import { Button } from 'components/ui'
-
-import { RiContrast2Fill, RiContrast2Line } from '@remixicon/react'
 
 const ThemeSelector = () => {
   const { theme, setTheme, resolvedTheme } = useTheme()

--- a/components/ToggleFullScreen.tsx
+++ b/components/ToggleFullScreen.tsx
@@ -1,6 +1,4 @@
-import { useTheme } from 'next-themes'
 import { useContext } from 'react'
-import { AppUiContext } from 'context/appUiContext'
 
 import {
   RiFullscreenExitFill,
@@ -8,6 +6,9 @@ import {
   RiFullscreenFill,
   RiFullscreenLine,
 } from '@remixicon/react'
+import { useTheme } from 'next-themes'
+
+import { AppUiContext } from 'context/appUiContext'
 
 import { Button } from 'components/ui'
 

--- a/components/Tracer/ExecutionStatus.tsx
+++ b/components/Tracer/ExecutionStatus.tsx
@@ -1,8 +1,7 @@
 import { useContext } from 'react'
 
-import ReactTooltip from 'react-tooltip'
-
 import { RiArrowGoForwardLine, RiArrowGoBackLine } from '@remixicon/react'
+import ReactTooltip from 'react-tooltip'
 
 import { Button } from 'components/ui'
 

--- a/components/Tracer/ExecutionStatus.tsx
+++ b/components/Tracer/ExecutionStatus.tsx
@@ -1,7 +1,4 @@
-import { useContext } from 'react'
-
 import { RiArrowGoForwardLine, RiArrowGoBackLine } from '@remixicon/react'
-import ReactTooltip from 'react-tooltip'
 
 import { Button } from 'components/ui'
 
@@ -19,36 +16,10 @@ const ExecutionStatus = ({
           Execution Trace
         </span>
       </div>
-      {/* <div>
-        <span className="inline-block ml-1 mr-2 text-gray-400">
-          <Icon name="gas-station-fill" className="text-indigo-500" />
-        </span>
-        <span className="inline-block mr-1 text-gray-500 text-sm select-none">
-          Current:
-        </span>
-        <span
-          className="inline-block mr-4 select-all cursor-help"
-          data-tip="Gas consumed for the current instruction"
-        >
-          {executionState.currentGas || 0}
-        </span>
-        <span className="inline-block mr-1 text-gray-500 text-sm select-none">
-          Total:
-        </span>
-        <span
-          className="inline-block mr-4 select-all cursor-help"
-          data-tip="Total gas consumed"
-        >
-          {executionState.totalGas || 0}
-        </span>
-
-        <ReactTooltip className="tooltip" effect="solid" />
-      </div> */}
 
       <div className="flex flex-row items-center gap-4">
         <Button
           transparent
-          // disabled={true}
           onClick={onStepOut}
           padded={false}
           tooltip="Step back"
@@ -58,7 +29,6 @@ const ExecutionStatus = ({
         </Button>
         <Button
           transparent
-          // disabled={!isExecuting}
           onClick={onStepIn}
           padded={false}
           tooltip="Step next"
@@ -66,17 +36,6 @@ const ExecutionStatus = ({
         >
           <RiArrowGoForwardLine size={16} className="text-indigo-500" />
         </Button>
-
-        {/* <Button
-          transparent
-          // disabled={!isExecuting}
-          // onClick={continueExecution}
-          padded={false}
-          tooltip="Continue execution"
-          tooltipId="continue"
-        >
-          <Icon name="play-circle-line" className="text-indigo-500" />
-        </Button> */}
       </div>
     </div>
   )

--- a/components/Tracer/index.tsx
+++ b/components/Tracer/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 
 import ReactTooltip from 'react-tooltip'
 
@@ -222,16 +222,7 @@ function InstructionsTable({
                 )}
                 {addrNum === fp && <span className="text-green-700">[fp]</span>}
               </td>
-              <td
-                className={`py-1 px-2 whitespace-nowrap ${
-                  // isCurrent
-                  // ? 'text-gray-400 dark:text-gray-600'
-                  // : 'text-gray-300 dark:text-gray-700'
-                  ''
-                }`}
-              >
-                {addr}
-              </td>
+              <td className="py-1 px-2 whitespace-nowrap">{addr}</td>
               <td className="py-1 px-2 max-w-40 break-words">{memory[addr]}</td>
               {pcInstMap[addr] && (
                 <>

--- a/components/Tracer/index.tsx
+++ b/components/Tracer/index.tsx
@@ -1,7 +1,10 @@
 import { useContext, useEffect, useRef, useState } from 'react'
-import ExecutionStatus from './ExecutionStatus'
+
 import ReactTooltip from 'react-tooltip'
+
 import { CairoVMApiContext } from 'context/cairoVMApiContext'
+
+import ExecutionStatus from './ExecutionStatus'
 
 export interface Instruction {
   ap_update: string

--- a/components/layouts/Home.tsx
+++ b/components/layouts/Home.tsx
@@ -1,6 +1,5 @@
 import { GoogleAnalytics } from '@next/third-parties/google'
 import type { NextPage } from 'next'
-// import { Html } from 'next/document'
 import Head from 'next/head'
 
 import { getAbsoluteURL } from 'util/browser'

--- a/components/layouts/Nav.tsx
+++ b/components/layouts/Nav.tsx
@@ -1,21 +1,14 @@
-import { useState } from 'react'
-
 import cn from 'classnames'
 import Link from 'next/link'
 
 import { GITHUB_REPO_URL } from 'util/constants'
 
-// import KBarButton from 'components/KBar/Button'
 import NavLink from 'components/NavLink'
 import ThemeSelector from 'components/ThemeSelector'
 import ToggleFullScreen from 'components/ToggleFullScreen'
-import { Container, Logo, Hamburger } from 'components/ui'
-
-// import ChainSelector from '../ChainSelector'
+import { Container, Logo } from 'components/ui'
 
 const Nav = () => {
-  const [isMenuVisible, setIsMenuVisible] = useState(false)
-
   return (
     <nav className="fixed z-40 top-0 inset-x-0 py-2 bg-white dark:bg-black-800">
       <Container>
@@ -29,37 +22,18 @@ const Nav = () => {
           <ul
             className={cn(
               'py-2 md:py-0 px-2 flex justify-between items-start md:items-center flex-col md:flex-row w-full md:w-auto fixed md:static shadow-md md:shadow-none transition-all',
-              {
-                'left-0 bg-white dark:bg-black-800 md:bg-transparent dark:md:bg-transparent':
-                  isMenuVisible,
-                '-left-full': !isMenuVisible,
-              },
+              '-left-full',
             )}
             style={{ top: 56 }}
-          >
-            {/* <NavLink href="/">Opcodes</NavLink> */}
-            {/* <NavLink href="/precompiled">Precompiled Contracts</NavLink> */}
-            {/* <NavLink href="/playground">Playground</NavLink> */}
-            {/* <NavLink href="/about">About</NavLink> */}
-
-            {/* <li className="hidden lg:inline-block">
-              <KBarButton />
-            </li> */}
-          </ul>
+          ></ul>
 
           <div className="items-center ml-auto flex">
-            {/* <ChainSelector /> */}
             <NavLink href={GITHUB_REPO_URL} external>
               GitHub
             </NavLink>
             <ToggleFullScreen />
             <ThemeSelector />
           </div>
-
-          {/* <Hamburger
-            isActive={isMenuVisible}
-            onClick={() => setIsMenuVisible(!isMenuVisible)}
-          /> */}
         </div>
       </Container>
     </nav>

--- a/components/ui/Container.tsx
+++ b/components/ui/Container.tsx
@@ -13,8 +13,6 @@ export const Container: React.FC<Props> = ({
   className,
   fullWidth,
 }) => {
-  // const renderAsFullWidth = fullWidth || false
-
   return (
     <div
       className={cn('mx-auto px-4 md:px-6', className, {

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -61,15 +61,6 @@ export const Input: React.FC<Props> = forwardRef(
             {isInputEmpty && (
               <span className="text-black-400 absolute right-8">Alt+K</span>
             )}
-            {/* <Icon
-              name="search-line"
-              className={cn(
-                'ml-2',
-                isFocused
-                  ? 'text-gray-400 dark:text-gray-300'
-                  : 'text-gray-300 dark:text-gray-400',
-              )}
-            /> */}
           </>
         )}
       </div>

--- a/components/ui/Message.tsx
+++ b/components/ui/Message.tsx
@@ -20,10 +20,6 @@ export const Message: React.FC<Props> = ({ type, text }) => {
     }
   }, [type])
 
-  const iconName = useMemo(() => {
-    return type === 'success' ? 'checkbox-circle-line' : 'error-warning-line'
-  }, [type])
-
   return (
     <div
       className={cn(
@@ -31,7 +27,6 @@ export const Message: React.FC<Props> = ({ type, text }) => {
         bgColor,
       )}
     >
-      {/* <Icon name={iconName} className="mr-1" /> */}
       {text}
     </div>
   )

--- a/lib/useActions.tsx
+++ b/lib/useActions.tsx
@@ -14,7 +14,6 @@ const useActions = () => {
       section: 'Navigation',
       perform: () => router.push('/'),
       subtitle: 'Opcodes reference',
-      // icon: <Icon name="home-2-line" />,
     },
     {
       id: 'precompiled',
@@ -24,7 +23,6 @@ const useActions = () => {
       section: 'Navigation',
       subtitle: 'Precompiled contracts reference',
       perform: () => router.push('/precompiled'),
-      // icon: <Icon name="information-line" />,
     },
     {
       id: 'playground',
@@ -34,7 +32,6 @@ const useActions = () => {
       section: 'Navigation',
       perform: () => router.push('/playground'),
       subtitle: 'Play with EVM in real-time',
-      // icon: <Icon name="play-circle-line" />,
     },
     {
       id: 'about',
@@ -44,7 +41,6 @@ const useActions = () => {
       section: 'Navigation',
       subtitle: 'About EVM and its internals',
       perform: () => router.push('/about'),
-      // icon: <Icon name="information-line" />,
     },
     {
       id: 'github',
@@ -54,7 +50,6 @@ const useActions = () => {
       section: 'Navigation',
       subtitle: 'Contribute on GitHub',
       perform: () => window.open(GITHUB_REPO_URL, '_blank'),
-      // icon: <Icon name="github-fill" />,
     },
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "eslint --ext js,jsx,ts,tsx .",
+    "lint:fix": "eslint --ext js,jsx,ts,tsx --fix .",
     "lint:package": "sort-package-json",
     "typecheck": "tsc --pretty"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,8 +6,9 @@ import type { NextPage } from 'next'
 import type { AppProps } from 'next/app'
 import { ThemeProvider } from 'next-themes'
 
-import { EthereumProvider } from 'context/ethereumContext'
+import { AppUiProvider } from 'context/appUiContext'
 import { CairoVMApiProvider } from 'context/cairoVMApiContext'
+import { EthereumProvider } from 'context/ethereumContext'
 import { SettingsProvider } from 'context/settingsContext'
 
 import KBar from 'components/KBar'
@@ -15,7 +16,6 @@ import KBar from 'components/KBar'
 import '../styles/globals.css'
 import '../styles/highlight/atom-one-light.css'
 import '../styles/highlight/atom-one-dark.css'
-import { AppUiProvider } from 'context/appUiContext'
 
 type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import Link from 'next/link'
 
 import HomeLayout from 'components/layouts/Home'
 import { Container, H1, H2, H3, RelativeLink } from 'components/ui'
@@ -37,12 +36,6 @@ const SectionWrapper: React.FC<SectionWrapperProps> = ({
         id={anchorKey}
         className="font-mono mb-4 justify-start relative items-center scroll-mt-14"
       >
-        <Link href={`/about#${anchorKey}`} legacyBehavior>
-          <a className="absolute -left-6">
-            {/* <Icon name="links-line" className="text-indigo-500" /> */}
-          </a>
-        </Link>
-
         {header}
       </div>
       <div>{children}</div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,9 +12,9 @@ import { IItemDocs, IGasDocs, IDocMeta } from 'types'
 
 import { AppUiContext } from 'context/appUiContext'
 
+import AboutCairoVMBanner from 'components/AboutCairoVMBanner'
 import ContributeBox from 'components/ContributeBox'
 import Editor from 'components/Editor'
-import AboutCairoVMBanner from 'components/AboutCairoVMBanner'
 import HomeLayout from 'components/layouts/Home'
 import ReferenceTable from 'components/Reference'
 import { H1, Container } from 'components/ui'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,7 @@
-import fs from 'fs'
-import path from 'path'
-
 import { useContext } from 'react'
 
-import matter from 'gray-matter'
 import type { NextPage } from 'next'
-import getConfig from 'next/config'
 import Head from 'next/head'
-import { serialize } from 'next-mdx-remote/serialize'
-import { IItemDocs, IGasDocs, IDocMeta } from 'types'
 
 import { AppUiContext } from 'context/appUiContext'
 
@@ -16,18 +9,9 @@ import AboutCairoVMBanner from 'components/AboutCairoVMBanner'
 import ContributeBox from 'components/ContributeBox'
 import Editor from 'components/Editor'
 import HomeLayout from 'components/layouts/Home'
-import ReferenceTable from 'components/Reference'
-import { H1, Container } from 'components/ui'
+import { Container } from 'components/ui'
 
-const { serverRuntimeConfig } = getConfig()
-
-const HomePage = ({
-  opcodeDocs,
-  gasDocs,
-}: {
-  opcodeDocs: IItemDocs
-  gasDocs: IGasDocs
-}) => {
+const HomePage = () => {
   const { isFullScreen } = useContext(AppUiContext)
 
   return (
@@ -41,11 +25,6 @@ const HomePage = ({
         />
       </Head>
       <AboutCairoVMBanner />
-      {/* <Container>
-        <H1>
-          An Ethereum Virtual Machine <br></br> Opcodes Interactive Reference
-        </H1>
-      </Container> */}
 
       <Container fullWidth={isFullScreen}>
         <Editor />
@@ -60,58 +39,6 @@ const HomePage = ({
 
 HomePage.getLayout = function getLayout(page: NextPage) {
   return <HomeLayout>{page}</HomeLayout>
-}
-
-export const getStaticProps = async () => {
-  const docsPath = path.join(serverRuntimeConfig.APP_ROOT, 'docs/opcodes')
-  const docs = fs.readdirSync(docsPath)
-
-  const opcodeDocs: IItemDocs = {}
-  const gasDocs: IGasDocs = {}
-
-  await Promise.all(
-    docs.map(async (doc) => {
-      const stat = fs.statSync(path.join(docsPath, doc))
-      const opcode = path.parse(doc).name.toLowerCase()
-
-      try {
-        if (stat?.isDirectory()) {
-          fs.readdirSync(path.join(docsPath, doc)).map((fileName) => {
-            const markdown = fs.readFileSync(
-              path.join(docsPath, doc, fileName),
-              'utf-8',
-            )
-            const forkName = path.parse(fileName).name
-            if (!(opcode in gasDocs)) {
-              gasDocs[opcode] = {}
-            }
-            gasDocs[opcode][forkName] = markdown
-          })
-        } else {
-          const markdownWithMeta = fs.readFileSync(
-            path.join(docsPath, doc),
-            'utf-8',
-          )
-          const { data, content } = matter(markdownWithMeta)
-          const meta = data as IDocMeta
-          const mdxSource = await serialize(content)
-
-          opcodeDocs[opcode] = {
-            meta,
-            mdxSource,
-          }
-        }
-      } catch (error) {
-        console.debug("Couldn't read the Markdown doc for the opcode", error)
-      }
-    }),
-  )
-  return {
-    props: {
-      opcodeDocs,
-      gasDocs,
-    },
-  }
 }
 
 export default HomePage

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -9,4 +9,3 @@ export const FORKS_WITH_TIMESTAMPS: { [name: string]: number } = {
 }
 
 export const CAIRO_VM_API_URL = 'https://api.cairovm.codes/v1/run'
-// export const CAIRO_VM_API_URL = 'http://localhost:3010/v1/run'


### PR DESCRIPTION
Related to https://github.com/walnuthq/cairovm.codes/issues/12

To ease this process, I've added a new npm script `lint:fix` which calls the linter with the `--fix` option (using `npm run lint --fix` does not work because the `--fix` option must be before the path `.`).

I also removed unused code in comments as these portions of code were direclty linked to the linter warnings (useless imports, useless variables and so on).

The dynamic fee documentation part in the `DocRow` component was not used but as it was quite big, I removed it in a dedicated commit. If it has to be kept for a future implementation, I can comment all of this to avoid having linter errors/warnings on it.