### PR TITLE
feat: add support of program arguments

### DIFF
--- a/components/Editor/EditorControls.tsx
+++ b/components/Editor/EditorControls.tsx
@@ -1,0 +1,74 @@
+import { useRef } from 'react'
+
+import { RiLinksLine } from '@remixicon/react'
+import cn from 'classnames'
+
+import { Button, Input } from 'components/ui'
+
+type EditorControlsProps = {
+  isCompileDisabled: boolean
+  programArguments: string
+  areProgramArgumentsValid: boolean
+  onCopyPermalink: () => void
+  onCompileRun: () => void
+  onProgramArgumentsUpdate: (args: string) => void
+}
+
+const EditorControls = ({
+  isCompileDisabled,
+  programArguments,
+  areProgramArgumentsValid,
+  onCopyPermalink,
+  onCompileRun,
+  onProgramArgumentsUpdate,
+}: EditorControlsProps) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-x-4 px-4 py-4 md:py-2 md:border-r border-gray-200 dark:border-black-500">
+      <div className="flex flex-col md:flex-row md:gap-x-4 gap-y-2 md:gap-y-0 mb-4 md:mb-0">
+        <Button
+          onClick={onCopyPermalink}
+          transparent
+          padded={false}
+          tooltip="Share permalink"
+          tooltipId="share-permalink"
+        >
+          <span className="inline-block mr-4 select-all">
+            <RiLinksLine size={16} className="text-indigo-500 mr-1" />
+          </span>
+        </Button>
+      </div>
+
+      <Input
+        ref={inputRef}
+        onChange={(e) => {
+          onProgramArgumentsUpdate(e.target.value)
+        }}
+        readOnly={isCompileDisabled}
+        value={programArguments}
+        placeholder={`Enter program parameters...`}
+        className={cn('grow border bg-gray-200 dark:bg-gray-800', {
+          'dark:border-gray-800 border-gray-200': areProgramArgumentsValid,
+          'border-red-500': !areProgramArgumentsValid,
+        })}
+        inputClassName={cn({
+          'text-red-500': !areProgramArgumentsValid,
+        })}
+      />
+
+      <div>
+        <Button
+          onClick={onCompileRun}
+          disabled={isCompileDisabled || !areProgramArgumentsValid}
+          size="sm"
+          contentClassName="justify-center"
+        >
+          Compile and run
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default EditorControls

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -6,11 +6,21 @@ type Props = {
   searchable?: boolean
   ref?: ForwardedRef<HTMLInputElement>
   className?: string
+  inputClassName?: string
+  readOnly?: boolean
 } & React.ComponentPropsWithoutRef<'input'>
 
 export const Input: React.FC<Props> = forwardRef(
   (
-    { searchable = false, onFocus, onBlur, className, ...rest },
+    {
+      searchable = false,
+      onFocus,
+      onBlur,
+      className,
+      inputClassName,
+      readOnly = false,
+      ...rest
+    },
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
     const [isFocused, setIsFocused] = useState(false)
@@ -50,10 +60,11 @@ export const Input: React.FC<Props> = forwardRef(
       >
         <input
           ref={ref}
+          readOnly={readOnly}
           onFocus={handleFocus}
           onBlur={handleBlur}
           onInput={handleInput}
-          className="w-full outline-none bg-transparent dark:placeholder-black-400"
+          className={`${inputClassName} w-full outline-none bg-transparent dark:placeholder-black-100`}
           {...rest}
         />
         {searchable && (

--- a/context/cairoVMApiContext.tsx
+++ b/context/cairoVMApiContext.tsx
@@ -25,7 +25,7 @@ type ContextProps = {
   activeCasmInstructionIndex: number
   currentTraceEntry?: TraceEntry
 
-  compileCairoCode: (cairoCode: string) => void
+  compileCairoCode: (cairoCode: string, programArguments: string) => void
   onExecutionStepChange: (step: number) => void
 }
 
@@ -67,7 +67,7 @@ export const CairoVMApiProvider: React.FC = ({ children }) => {
     setExecutionTraceStepNumber(stepNumber)
   }
 
-  const compileCairoCode = (cairoCode: string) => {
+  const compileCairoCode = (cairoCode: string, programArguments = '') => {
     setIsCompiling(CompilationState.Compiling)
 
     fetch(CAIRO_VM_API_URL, {
@@ -75,7 +75,10 @@ export const CairoVMApiProvider: React.FC = ({ children }) => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ cairo_program_code: cairoCode }),
+      body: JSON.stringify({
+        cairo_program_code: cairoCode,
+        program_arguments: programArguments,
+      }),
     })
       .then((response) => response.json())
       .then((data) => {

--- a/util/compiler.ts
+++ b/util/compiler.ts
@@ -148,3 +148,73 @@ export const getBytecodeLinesFromInstructions = (
     .map((i) => `${i.name}${i.value ? ' 0x' + i.value : ''}`)
     .join('\n')
 }
+
+export const isPositiveInteger = (value: string): boolean =>
+  /^[0-9]+$/.test(value)
+
+// on the back-end side, a felt252 is decoded from a decimal value stored in the string.
+// That means, short string or hexadecimal value are not supported.
+export const isValidFelt252 = (value: string): boolean => {
+  if (!isPositiveInteger(value)) {
+    return false
+  }
+
+  const bnValue = new BN(value)
+  const minFeltValue = new BN('0')
+  const maxFeltValue = new BN(
+    '3618502788666131213697322783095070105623107215331596699973092056135872020480',
+  )
+
+  return bnValue.gte(minFeltValue) && bnValue.lte(maxFeltValue)
+}
+
+// check if a program arguments string is valid.
+// this string should contain a list of arguments separated by a space.
+// an argument could be:
+//  - a felt252 decimal value
+//  - an array of felt252 where every values are separated by a space.
+export const isArgumentStringValid = (value: string) => {
+  if (value.length === 0) return true
+
+  const items = value.split(' ')
+  let index = 0
+
+  while (index < items.length) {
+    if (items[index].startsWith('[')) {
+      // special case of empty or one-element array
+      if (items[index].endsWith(']')) {
+        const x = items[index].slice(1, -1)
+        if (x.length > 0 && !isValidFelt252(x)) {
+          return false
+        }
+      } else {
+        // multi-element array
+        let endOfArray = index + 1
+        while (endOfArray < items.length && !items[endOfArray].endsWith(']')) {
+          endOfArray += 1
+        }
+        if (endOfArray >= items.length) {
+          return false
+        }
+
+        const arrayValues = [
+          items[index].slice(1), // the first value without the [
+          ...items.slice(index + 1, endOfArray),
+          items[endOfArray].slice(0, -1), // the last value without the ]
+        ]
+        if (!arrayValues.every((x) => isValidFelt252(x))) {
+          return false
+        }
+
+        index = endOfArray + 1
+        continue
+      }
+    } else if (!isValidFelt252(items[index])) {
+      return false
+    }
+
+    index += 1
+  }
+
+  return true
+}

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -8,4 +8,5 @@ export const FORKS_WITH_TIMESTAMPS: { [name: string]: number } = {
   shanghai: 1681338455,
 }
 
-export const CAIRO_VM_API_URL = 'https://api.cairovm.codes/v1/run'
+export const CAIRO_VM_API_URL =
+  process.env.NEXT_PUBLIC_CAIRO_VM_API_URL || 'https://api.cairovm.codes/v1/run'


### PR DESCRIPTION
related to https://github.com/walnuthq/cairovm.codes/issues/17

A new input field accepts program arguments separated by a whitespace. Each parameter could be a single value (i.e a `felt252`) or an array of values (i.e array of `felt252`).

I used the whitespace instead of the coma as separator because, on the back-end side, the argument parsing was already implemented in the `process_args` function. Of course, it can be adapted if needed !

That means:
* every parameters are separated by a space
* a parameter could be a single felt252 or an array of felt252
* every items in an array are separated by a space.

For example `1 [3 4 5] 9` contains 3 parameters.

The user input is sanitized (extra whitespaces are removed) and validated (text input in red if not valid and the 'run' button is disabled).