### PR TITLE
chore: add a Github action to typecheck and lint a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type checking
+        run: npm run typecheck
+
+      - name: Linting
+        run: npm run lint:fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run typecheck && yarn run lint:fix
+npm run typecheck && npm run lint:fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run typecheck && yarn run lint --fix
+yarn run typecheck && yarn run lint:fix

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "lint": "eslint --ext js,jsx,ts,tsx .",
-    "lint:fix": "eslint --ext js,jsx,ts,tsx --fix .",
+    "lint": "eslint --ext js,jsx,ts,tsx --max-warnings=0 .",
+    "lint:fix": "eslint --ext js,jsx,ts,tsx --max-warnings=0 --fix .",
     "lint:package": "sort-package-json",
     "typecheck": "tsc --pretty"
   },


### PR DESCRIPTION
Related to https://github.com/walnuthq/cairovm.codes/issues/45.

The `--max-warnings=0` option has been added to lint scripts in `package.json` in order to consider a warning as an error when linting the project. Thanks to that, the Github action and the Husky pre-commit hook will fail in case of warnings.