### PR TITLE
chore: fix trace table ovelapping the arguments modal

### DIFF
--- a/components/Editor/ArgumentsHelperModal.tsx
+++ b/components/Editor/ArgumentsHelperModal.tsx
@@ -1,0 +1,66 @@
+import { Modal } from 'components/ui'
+
+type Props = {
+  showArgumentsHelper: boolean
+  setShowArgumentsHelper: (_visible: boolean) => void
+}
+
+export const ArgumentsHelperModal = ({
+  showArgumentsHelper,
+  setShowArgumentsHelper,
+}: Props) => {
+  return (
+    <Modal
+      title="Program arguments helper"
+      visible={showArgumentsHelper}
+      setVisible={setShowArgumentsHelper}
+    >
+      <div
+        className="text-sm md:text-md lg:text-lg"
+        role="button"
+        tabIndex={0}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <p className="my-2">
+          This input field accepts a list of program arguments separated by a{' '}
+          <span className="font-semibold">whitespace</span>.
+        </p>
+        <p className="my-2">Each argument could be:</p>
+        <ul className="list-disc ml-4">
+          <li>
+            a <span className="font-semibold">single</span>
+            <code className="mx-1 text-orange-600">felt252</code>,
+          </li>
+          <li>
+            an <span className="font-semibold">array</span> of
+            <code className="mx-1 text-orange-600">felt252</code> where items
+            are also separated by a{' '}
+            <span className="font-semibold">whitespace</span>.
+          </li>
+        </ul>
+        <p className="mt-2 italic">
+          Note that only decimal values are supported for{' '}
+          <code className="mx-1 text-orange-600">felt252</code>. That means
+          neither hexadecimal value nor short string are supported yet.
+        </p>
+        <p className="mt-4">
+          Of course, the signature of your{' '}
+          <code className="mx-1 text-orange-600">main()</code> function must be
+          adapted accordingly.
+        </p>
+        <p className="mt-6">
+          For example,{' '}
+          <code className="px-1 bg-gray-200 dark:bg-gray-600 text-orange-600">
+            1 [3 4 5] 9
+          </code>{' '}
+          contains 3 arguments and the corresponding main function should be{' '}
+          <code className="mx-1 text-orange-600">
+            main(x: felt252, y: Array&lt;felt252&gt;, z: felt252)
+          </code>
+          .
+        </p>
+      </div>
+    </Modal>
+  )
+}

--- a/components/Editor/EditorControls.tsx
+++ b/components/Editor/EditorControls.tsx
@@ -1,9 +1,9 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 
 import { RiLinksLine, RiQuestionLine } from '@remixicon/react'
 import cn from 'classnames'
 
-import { Button, Input, Modal } from 'components/ui'
+import { Button, Input } from 'components/ui'
 
 type EditorControlsProps = {
   isCompileDisabled: boolean
@@ -12,6 +12,7 @@ type EditorControlsProps = {
   onCopyPermalink: () => void
   onCompileRun: () => void
   onProgramArgumentsUpdate: (args: string) => void
+  onShowArgumentsHelper: () => void
 }
 
 const EditorControls = ({
@@ -21,70 +22,9 @@ const EditorControls = ({
   onCopyPermalink,
   onCompileRun,
   onProgramArgumentsUpdate,
+  onShowArgumentsHelper,
 }: EditorControlsProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
-  const [showArgumentsHelper, setShowArgumentsHelper] = useState(false)
-
-  const argumentHelperModal = (
-    <Modal
-      title="Program arguments helper"
-      visible={showArgumentsHelper}
-      setVisible={setShowArgumentsHelper}
-    >
-      <div
-        className="text-sm md:text-md lg:text-lg text-gray-900 dark:text-gray-900"
-        role="button"
-        tabIndex={0}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        <p className="my-2">
-          This input field accepts a list of program arguments separated by a{' '}
-          <span className="font-semibold">whitespace</span>.
-        </p>
-        <p className="my-2">Each argument could be:</p>
-        <ul className="list-disc ml-4">
-          <li>
-            a <span className="font-semibold">single</span>
-            <code className="mx-1 text-orange-600">felt252</code>,
-          </li>
-          <li>
-            an <span className="font-semibold">array</span> of
-            <code className="mx-1 text-orange-600">felt252</code> where items
-            are also separated by a{' '}
-            <span className="font-semibold">whitespace</span>.
-          </li>
-        </ul>
-        <p className="mt-2 italic">
-          Note that only decimal values are supported for{' '}
-          <code className="mx-1 text-orange-600">felt252</code>. That means
-          neither hexadecimal value nor short string are supported yet.
-        </p>
-        <p className="mt-4">
-          Of course, the signature of your{' '}
-          <code className="mx-1 text-orange-600">main()</code> function must be
-          adapted accordingly.
-        </p>
-        <p className="mt-6">
-          For example,{' '}
-          <code className="px-1 bg-gray-200 text-orange-600">1 [3 4 5] 9</code>{' '}
-          contains 3 arguments and the corresponding main function should be{' '}
-          <code className="mx-1 text-orange-600">
-            main(x: felt252, y: Array&lt;felt252&gt;, z: felt252)
-          </code>
-          .
-        </p>
-      </div>
-    </Modal>
-  )
-  const argumentHelperIcon = (
-    <>
-      <button onClick={() => setShowArgumentsHelper(true)}>
-        <RiQuestionLine size={20} className="text-gray-400" />
-      </button>
-      {showArgumentsHelper && argumentHelperModal}
-    </>
-  )
 
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-x-4 px-4 py-4 md:py-2 md:border-r border-gray-200 dark:border-black-500">
@@ -104,7 +44,11 @@ const EditorControls = ({
 
       <Input
         ref={inputRef}
-        rightIcon={argumentHelperIcon}
+        rightIcon={
+          <button onClick={onShowArgumentsHelper}>
+            <RiQuestionLine size={20} className="text-gray-400" />
+          </button>
+        }
         onChange={(e) => {
           onProgramArgumentsUpdate(e.target.value)
         }}

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -26,6 +26,7 @@ import { Tracer } from 'components/Tracer'
 
 import { ILogEntry } from '../../types'
 
+import { ArgumentsHelperModal } from './ArgumentsHelperModal'
 import Console from './Console'
 import EditorControls from './EditorControls'
 import Header from './Header'
@@ -71,6 +72,7 @@ const Editor = ({ readOnly = false }: Props) => {
     },
   ])
   const editorRef = useRef<SCEditorRef>()
+  const [showArgumentsHelper, setShowArgumentsHelper] = useState(false)
 
   const log = useCallback(
     (line: string, type = LogType.Info) => {
@@ -194,88 +196,95 @@ const Editor = ({ readOnly = false }: Props) => {
   const isBytecode = false
 
   return (
-    <div className="bg-gray-100 dark:bg-black-700 rounded-lg">
-      <div className="flex flex-col md:flex-row">
-        <div className="w-full md:w-1/2">
-          <div className="border-b border-gray-200 dark:border-black-500 flex items-center pl-6 pr-2 h-14 md:border-r">
-            <Header
-              codeType={codeType}
-              onCodeTypeChange={({ value }) => setCodeType(value)}
-            />
-          </div>
-
-          <div>
-            <div
-              className="relative pane pane-light overflow-auto md:border-r bg-gray-50 dark:bg-black-600 border-gray-200 dark:border-black-500"
-              style={{ height: cairoEditorHeight }}
-            >
-              {codeType === CodeType.CASM ? (
-                <InstructionsTable
-                  instructions={casmInstructions}
-                  activeIndex={activeCasmInstructionIndex}
-                  height={cairoEditorHeight}
-                />
-              ) : (
-                <SCEditor
-                  // @ts-ignore: SCEditor is not TS-friendly
-                  ref={editorRef}
-                  value={
-                    codeType === CodeType.Cairo
-                      ? cairoCode
-                      : codeType === CodeType.Sierra
-                      ? sierraCode
-                      : codeType === CodeType.CASM
-                      ? casmCode
-                      : ''
-                  }
-                  readOnly={readOnly}
-                  onValueChange={handleCairoCodeChange}
-                  highlight={highlightCode}
-                  tabSize={4}
-                  className={cn('code-editor', {
-                    'with-numbers': !isBytecode,
-                  })}
-                />
-              )}
+    <>
+      <div className="bg-gray-100 dark:bg-black-700 rounded-lg">
+        <div className="flex flex-col md:flex-row">
+          <div className="w-full md:w-1/2">
+            <div className="border-b border-gray-200 dark:border-black-500 flex items-center pl-6 pr-2 h-14 md:border-r">
+              <Header
+                codeType={codeType}
+                onCodeTypeChange={({ value }) => setCodeType(value)}
+              />
             </div>
 
-            <EditorControls
-              isCompileDisabled={isCompileDisabled}
-              programArguments={programArguments}
-              areProgramArgumentsValid={areProgramArgumentsValid}
-              onCopyPermalink={handleCopyPermalink}
-              onProgramArgumentsUpdate={handleProgramArgumentsUpdate}
-              onCompileRun={handleCompileRun}
+            <div>
+              <div
+                className="relative pane pane-light overflow-auto md:border-r bg-gray-50 dark:bg-black-600 border-gray-200 dark:border-black-500"
+                style={{ height: cairoEditorHeight }}
+              >
+                {codeType === CodeType.CASM ? (
+                  <InstructionsTable
+                    instructions={casmInstructions}
+                    activeIndex={activeCasmInstructionIndex}
+                    height={cairoEditorHeight}
+                  />
+                ) : (
+                  <SCEditor
+                    // @ts-ignore: SCEditor is not TS-friendly
+                    ref={editorRef}
+                    value={
+                      codeType === CodeType.Cairo
+                        ? cairoCode
+                        : codeType === CodeType.Sierra
+                        ? sierraCode
+                        : codeType === CodeType.CASM
+                        ? casmCode
+                        : ''
+                    }
+                    readOnly={readOnly}
+                    onValueChange={handleCairoCodeChange}
+                    highlight={highlightCode}
+                    tabSize={4}
+                    className={cn('code-editor', {
+                      'with-numbers': !isBytecode,
+                    })}
+                  />
+                )}
+              </div>
+
+              <EditorControls
+                isCompileDisabled={isCompileDisabled}
+                programArguments={programArguments}
+                areProgramArgumentsValid={areProgramArgumentsValid}
+                onCopyPermalink={handleCopyPermalink}
+                onProgramArgumentsUpdate={handleProgramArgumentsUpdate}
+                onCompileRun={handleCompileRun}
+                onShowArgumentsHelper={() => setShowArgumentsHelper(true)}
+              />
+            </div>
+          </div>
+
+          <div className="w-full md:w-1/2">
+            <Tracer
+              tracerData={tracerData}
+              mainHeight={cairoEditorHeight}
+              barHeight={runBarHeight}
             />
           </div>
         </div>
 
-        <div className="w-full md:w-1/2">
-          <Tracer
-            tracerData={tracerData}
-            mainHeight={cairoEditorHeight}
-            barHeight={runBarHeight}
-          />
-        </div>
-      </div>
-
-      <div className="flex flex-col md:flex-row-reverse">
-        <div className="w-full">
-          <div
-            className="pane pane-dark overflow-auto bg-gray-800 dark:bg-black-700 text-white border-t border-black-900/25 md:border-r"
-            style={{ height: consoleHeight }}
-          >
-            <Console output={output} />
+        <div className="flex flex-col md:flex-row-reverse">
+          <div className="w-full">
+            <div
+              className="pane pane-dark overflow-auto bg-gray-800 dark:bg-black-700 text-white border-t border-black-900/25 md:border-r"
+              style={{ height: consoleHeight }}
+            >
+              <Console output={output} />
+            </div>
           </div>
         </div>
-      </div>
 
-      <div className="rounded-b-lg py-2 px-4 border-t bg-gray-800 dark:bg-black-700 border-black-900/25 text-gray-400 dark:text-gray-600 text-xs">
-        {cairoLangCompilerVersion !== ''
-          ? `Cairo Compiler v${cairoLangCompilerVersion}`
-          : ' '}
+        <div className="rounded-b-lg py-2 px-4 border-t bg-gray-800 dark:bg-black-700 border-black-900/25 text-gray-400 dark:text-gray-600 text-xs">
+          {cairoLangCompilerVersion !== ''
+            ? `Cairo Compiler v${cairoLangCompilerVersion}`
+            : ' '}
+        </div>
       </div>
-    </div>
+      <ArgumentsHelperModal
+        showArgumentsHelper={showArgumentsHelper}
+        setShowArgumentsHelper={setShowArgumentsHelper}
+      />
+    </>
   )
 }
 

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -17,16 +17,16 @@ export const Modal = ({
 
   return visible ? (
     <div
-      className="flex fixed top-0 left-0 z-80 w-screen h-screen bg-gray-800/30 dark:bg-gray-800/50 justify-center items-center"
+      className="flex fixed top-0 left-0 z-80 w-screen h-screen bg-gray-800/50 dark:bg-gray-800/50 justify-center items-center"
       role="button"
       tabIndex={0}
       onClick={closeModal}
       onKeyDown={closeModal}
     >
       <div className="fixed inset-0 z-50 overflow-auto bg-black/80 flex">
-        <div className="max-w-lg lg:max-w-3xl relative p-4 bg-white w-full m-auto flex-col flex rounded-lg">
+        <div className="max-w-lg lg:max-w-3xl relative p-4 bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-400 w-full m-auto flex-col flex rounded-lg">
           <div className="flex flex-row justify-between pb-2 border-b border-slate-300 mb-4">
-            <h2 className="text-sm md:text-md lg:text-lg text-gray-900 dark:text-gray-900 font-semibold">
+            <h2 className="text-sm md:text-md lg:text-lg font-semibold">
               {title}
             </h2>
             <button onClick={closeModal} aria-label="Close modal">


### PR DESCRIPTION
To fix this overlapping issue I moved the "arguments" modal from the `EditorControls` component to the end of the `Editor` component, as it's always better to extract modals from deep `div` hierarchies.
At the same time, I've created a dedicated component for this modal, to avoid "polluting" the `Editor` component file.

I've also set specific colors for the modal in dark mode.