### PR TITLE
fix: set banner closed in local storage

### DIFF
--- a/components/AboutCairoVMBanner.tsx
+++ b/components/AboutCairoVMBanner.tsx
@@ -14,6 +14,7 @@ const AboutCairoVMBanner = () => {
   }, [])
 
   const handleCloseBanner = () => {
+    localStorage.setItem('isBannerClosed', 'closed')
     setIsShown(false)
   }
 


### PR DESCRIPTION
The feature to hide the about banner when closed was already implemented but the local storage flag was never set.
This PR sets the flag in the local storage.