### PR TITLE
[chore] add Vercel preview for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,21 @@
+name: Vercel
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  pull_request_target:
+    types: [labeled]
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.url }}
+    if: contains(github.event.pull_request.labels.*.name, 'safe to preview')
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install --global vercel@latest
+      - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        run: echo "::set-output name=url::$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"


### PR DESCRIPTION
This PR adds a Github action `Vercel / Preview` which build and deploy the cairovm.codes front-end to Vercel for every PR.

A button `View Deployment` is automatically posted on the PR by the Vercel bot.

Note to configure Github and Vercel properly:
* First of all, you need to install the Vercel CLI tool:
   * `npm i -g vercel@latest`
   * In your local git checkout of `cairovm.codes`, enter `vercel login` to log in to Vercel and then `vercel link` to create the project on Vercel and generate a `.vercel` folder in local (this folder is ignored by git).
* Go in the settings panel of your Vercel account on vercel.com. In Tokens, create a new one dedicated to `cairovm.codes` and don't forget to copy it.
* Go to the settings of the `cairovm.codes` repository on Github. In "Secrets and Variables" > "Actions", create 3 new repository secrets:
   * VERCEL_ORG_ID: copy the `orgId` value from .vercel/project.json file,
   * VERCEL_PROJECT_ID: copy the `projectId` value from .vercel/project.json file,
  * VERCEL_TOKEN: copy the previously created vercel token.

Now, each time a PR is created, a new action should be visible and the deployed version should be accessible.

**Still to be done**: check deployed version access to see if anyone can access to the deployed version or if something has to be configured in the Vercel project settings.