### PR TITLE
[fix] fix dangerously error on landing

### DIFF
--- a/components/Editor/Header.tsx
+++ b/components/Editor/Header.tsx
@@ -37,6 +37,7 @@ const EditorHeader = ({ codeType, onCodeTypeChange }: Props) => {
           isSearchable={false}
           classNamePrefix="select"
           menuPlacement="auto"
+          instanceId="headerSelect"
         />
       </div>
     </div>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -66,6 +66,7 @@ export const Button: React.FC<Props> = ({
           className="tooltip"
           id={tooltipIdPrefixed}
           effect="solid"
+          uuid="buttonTooltip" // see https://github.com/ReactTooltip/react-tooltip/issues/587#issuecomment-619675399
         />
       )}
     </button>


### PR DESCRIPTION
Fix #50 based on this https://github.com/ReactTooltip/react-tooltip/issues/587#issuecomment-619675399

After this error, there was another server-rendering issue with react-select “Warning: Prop `id` did not match” that I fixed with a fixed instanceId. A better fix would be to use the useId() hook but it's only available on React 18.

`import React, { useId } from 'react';`

There is one remaining issue for mac devices only I think `Extra attributes from the server: aria-activedescendant`.
Everything seems linked to the fact that react-select does not render isomorphically.

There is [an attempt to fix it](https://github.com/JedWatson/react-select/issues/5859) specifically here, I'd suggest to wait and see if the PR get merged



