### PR TITLE
Bring back kbar

### DIFF
--- a/components/Editor/EditorControls.tsx
+++ b/components/Editor/EditorControls.tsx
@@ -4,6 +4,7 @@ import { RiLinksLine, RiQuestionLine } from '@remixicon/react'
 import cn from 'classnames'
 
 import { Button, Input } from 'components/ui'
+import { useRegisterActions } from 'kbar'
 
 type EditorControlsProps = {
   isCompileDisabled: boolean
@@ -25,6 +26,21 @@ const EditorControls = ({
   onShowArgumentsHelper,
 }: EditorControlsProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const actions = [
+    {
+      id: 'compile',
+      name: 'Compile and run',
+      shortcut: ['r'],
+      keywords: 'compile run',
+      section: 'Execution',
+      perform: () => {
+        onCompileRun()
+      },
+    },
+  ]
+
+  useRegisterActions(actions, [onCompileRun])
 
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-x-4 px-4 py-4 md:py-2 md:border-r border-gray-200 dark:border-black-500">

--- a/components/Editor/EditorControls.tsx
+++ b/components/Editor/EditorControls.tsx
@@ -4,7 +4,7 @@ import { RiLinksLine, RiQuestionLine } from '@remixicon/react'
 import cn from 'classnames'
 
 import { Button, Input } from 'components/ui'
-import { useRegisterActions } from 'kbar'
+import { Priority, useRegisterActions } from 'kbar'
 
 type EditorControlsProps = {
   isCompileDisabled: boolean
@@ -37,6 +37,7 @@ const EditorControls = ({
       perform: () => {
         onCompileRun()
       },
+      priority: Priority.HIGH,
     },
   ]
 

--- a/components/KBar/Button.tsx
+++ b/components/KBar/Button.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+
 import { useKBar } from 'kbar'
 
 import { isMac } from 'util/browser'
@@ -6,6 +8,15 @@ import { Button } from 'components/ui'
 
 const KBarButton = () => {
   const { query } = useKBar()
+  const [isMacUser, setIsMacUser] = useState(false)
+
+  useEffect(() => {
+    const checkIfMacUser = () => {
+      setIsMacUser(isMac)
+    }
+
+    checkIfMacUser()
+  }, [])
 
   return (
     <Button
@@ -17,7 +28,7 @@ const KBarButton = () => {
       padded={false}
     >
       {/* {isMac && <Icon name="command-line" className="mr-1" />} */}
-      {isMac ? <span>K</span> : <span>Ctrl + K</span>}
+      {isMacUser ? <span>Cmd + K</span> : <span>Ctrl + K</span>}
     </Button>
   )
 }

--- a/components/KBar/Results.tsx
+++ b/components/KBar/Results.tsx
@@ -7,6 +7,7 @@ const Results = () => {
 
   return (
     <KBarResults
+      maxHeight={500}
       items={groups}
       onRender={({ item, active }) =>
         typeof item === 'string' ? (

--- a/components/KBar/Results.tsx
+++ b/components/KBar/Results.tsx
@@ -1,26 +1,13 @@
-import { useMemo } from 'react'
-
 import { KBarResults, useMatches } from 'kbar'
 
 import ResultItem from './ResultItem'
 
-const NO_GROUP = 'none'
-
 const Results = () => {
   const groups = useMatches().results
-  const flattened = useMemo(
-    () =>
-      groups.reduce((acc: any, curr: any) => {
-        acc.push(curr.name)
-        acc.push(...curr.actions)
-        return acc
-      }, []),
-    [groups],
-  )
 
   return (
     <KBarResults
-      items={flattened.filter((i: string) => i !== NO_GROUP)}
+      items={groups}
       onRender={({ item, active }) =>
         typeof item === 'string' ? (
           <div className="px-4 py-2 text-2xs uppercase text-gray-400 dark:text-gray-600 bg-white dark:bg-black-600">

--- a/components/KBar/index.tsx
+++ b/components/KBar/index.tsx
@@ -5,7 +5,7 @@ import Results from './Results'
 const KBar = () => {
   return (
     <KBarPortal>
-      <KBarPositioner className="inset-0">
+      <KBarPositioner className="inset-0 z-50">
         <KBarAnimator className="shadow-lg overflow-hidden rounded-md text-gray-800 dark:text-gray-400 bg-white dark:bg-black-600 w-full max-w-xl border border-gray-200 dark:border-black-700 text-sm">
           <KBarSearch
             className="w-full border-0 outline-none bg-white dark:bg-black-600 text-gray-800 dark:text-gray-100 font-sm px-4 py-4 border-box"

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -13,6 +13,7 @@ const ThemeSelector = () => {
       name: 'Change theme…',
       keywords: 'interface color dark light',
       section: 'Preferences',
+      shortcut: ['t'],
     },
     {
       id: 'theme-light',
@@ -40,13 +41,6 @@ const ThemeSelector = () => {
       section: '',
       perform: () => setTheme('system'),
       parent: 'theme',
-    },
-    {
-      id: 'theme',
-      name: 'Select theme…',
-      shortcut: ['t'],
-      keywords: 'theme appearance',
-      section: 'Preferences',
     },
   ]
 

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -1,5 +1,5 @@
 import { RiContrast2Fill, RiContrast2Line } from '@remixicon/react'
-import { useRegisterActions, Action } from 'kbar'
+import { useRegisterActions, Action, Priority } from 'kbar'
 import { useTheme } from 'next-themes'
 
 import { Button } from 'components/ui'
@@ -14,6 +14,7 @@ const ThemeSelector = () => {
       keywords: 'interface color dark light',
       section: 'Preferences',
       shortcut: ['t'],
+      priority: Priority.LOW,
     },
     {
       id: 'theme-light',

--- a/components/ToggleFullScreen.tsx
+++ b/components/ToggleFullScreen.tsx
@@ -6,7 +6,7 @@ import {
   RiFullscreenFill,
   RiFullscreenLine,
 } from '@remixicon/react'
-import { Action, useRegisterActions } from 'kbar'
+import { Action, Priority, useRegisterActions } from 'kbar'
 import { useTheme } from 'next-themes'
 
 import { AppUiContext } from 'context/appUiContext'
@@ -29,6 +29,7 @@ const ToggleFullScreen = () => {
       perform: () => {
         toggleFullScreen()
       },
+      priority: Priority.LOW,
     },
   ]
 

--- a/components/ToggleFullScreen.tsx
+++ b/components/ToggleFullScreen.tsx
@@ -6,6 +6,7 @@ import {
   RiFullscreenFill,
   RiFullscreenLine,
 } from '@remixicon/react'
+import { Action, useRegisterActions } from 'kbar'
 import { useTheme } from 'next-themes'
 
 import { AppUiContext } from 'context/appUiContext'
@@ -16,6 +17,22 @@ const ToggleFullScreen = () => {
   const { isFullScreen, toggleFullScreen } = useContext(AppUiContext)
 
   const { resolvedTheme } = useTheme()
+
+  const actions: Action[] = [
+    {
+      id: 'fullscreen',
+      name: 'Full Screen',
+      shortcut: ['f'],
+      keywords: 'full screen',
+      section: 'Preferences',
+      subtitle: 'Enter / Exit Full Screen',
+      perform: () => {
+        toggleFullScreen()
+      },
+    },
+  ]
+
+  useRegisterActions(actions, [actions])
 
   const handleToggleFullScreen = () => {
     toggleFullScreen()

--- a/components/Tracer/ExecutionStatus.tsx
+++ b/components/Tracer/ExecutionStatus.tsx
@@ -3,6 +3,7 @@ import {
   RiArrowGoBackLine,
   RiPlayCircleLine,
 } from '@remixicon/react'
+import { useRegisterActions } from 'kbar'
 
 import { Button } from 'components/ui'
 
@@ -15,6 +16,44 @@ const ExecutionStatus = ({
   onStepOut: () => void
   onContinueExecution: () => void
 }) => {
+  const actions = [
+    {
+      id: 'stepnext',
+      name: 'Step Next',
+      shortcut: ['n'],
+      keywords: 'step next',
+      section: 'Execution',
+      perform: () => {
+        onStepIn()
+      },
+      subtitle: 'Run next execution',
+    },
+    {
+      id: 'stepback',
+      name: 'Step Back',
+      shortcut: ['b'],
+      keywords: 'execution back',
+      section: 'Execution',
+      perform: () => {
+        onStepOut()
+      },
+      subtitle: 'Run back execution',
+    },
+    {
+      id: 'continue',
+      name: 'Continue',
+      shortcut: ['c'],
+      keywords: 'execution continue',
+      section: 'Execution',
+      perform: () => {
+        onContinueExecution()
+      },
+      subtitle: 'Continue execution',
+    },
+  ]
+
+  useRegisterActions(actions, [onStepIn, onStepOut, onContinueExecution])
+
   return (
     <div className="flex flex-grow justify-between items-center text-sm">
       <div>

--- a/components/Tracer/ExecutionStatus.tsx
+++ b/components/Tracer/ExecutionStatus.tsx
@@ -3,7 +3,7 @@ import {
   RiArrowGoBackLine,
   RiPlayCircleLine,
 } from '@remixicon/react'
-import { useRegisterActions } from 'kbar'
+import { Priority, useRegisterActions } from 'kbar'
 
 import { Button } from 'components/ui'
 
@@ -27,6 +27,7 @@ const ExecutionStatus = ({
         onStepIn()
       },
       subtitle: 'Run next execution',
+      priority: Priority.HIGH,
     },
     {
       id: 'stepback',
@@ -38,6 +39,7 @@ const ExecutionStatus = ({
         onStepOut()
       },
       subtitle: 'Run back execution',
+      priority: Priority.HIGH,
     },
     {
       id: 'continue',
@@ -49,6 +51,7 @@ const ExecutionStatus = ({
         onContinueExecution()
       },
       subtitle: 'Continue execution',
+      priority: Priority.HIGH,
     },
   ]
 

--- a/components/layouts/Nav.tsx
+++ b/components/layouts/Nav.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 import { GITHUB_REPO_URL } from 'util/constants'
 
+import KBarButton from 'components/KBar/Button'
 import NavLink from 'components/NavLink'
 import ThemeSelector from 'components/ThemeSelector'
 import ToggleFullScreen from 'components/ToggleFullScreen'
@@ -28,6 +29,7 @@ const Nav = () => {
           ></ul>
 
           <div className="items-center ml-auto flex">
+            <KBarButton />
             <NavLink href={GITHUB_REPO_URL} external>
               GitHub
             </NavLink>

--- a/lib/useActions.tsx
+++ b/lib/useActions.tsx
@@ -1,47 +1,7 @@
-import { useRouter } from 'next/router'
-
 import { GITHUB_REPO_URL } from 'util/constants'
 
 const useActions = () => {
-  const router = useRouter()
-
   return [
-    {
-      id: 'opcodes',
-      name: 'Opcodes',
-      shortcut: ['o'],
-      keywords: 'home opcodes back',
-      section: 'Navigation',
-      perform: () => router.push('/'),
-      subtitle: 'Opcodes reference',
-    },
-    {
-      id: 'precompiled',
-      name: 'Precompiled',
-      shortcut: ['a'],
-      keywords: 'precompiled contracts',
-      section: 'Navigation',
-      subtitle: 'Precompiled contracts reference',
-      perform: () => router.push('/precompiled'),
-    },
-    {
-      id: 'playground',
-      name: 'Playground',
-      shortcut: ['p'],
-      keywords: 'editor play',
-      section: 'Navigation',
-      perform: () => router.push('/playground'),
-      subtitle: 'Play with EVM in real-time',
-    },
-    {
-      id: 'about',
-      name: 'About',
-      shortcut: ['a'],
-      keywords: 'about EVM',
-      section: 'Navigation',
-      subtitle: 'About EVM and its internals',
-      perform: () => router.push('/about'),
-    },
     {
       id: 'github',
       name: 'GitHub',


### PR DESCRIPTION
Fix #53 

Two possibilities:
- display kbar by clicking on the K button in the navbar or pressing Ctrl+K (Cmd+K for mac users), and select one option in the menu
- directly run shortcuts from the homepage

Basically you can just load the page and:
- type "f" to enter/exit full screen mode
- type "r" to compile and run
- type "n" and "b" to step next and back on the execution
- type "c" to continue execution

![Feb-29-2024 22-12-17](https://github.com/walnuthq/cairovm.codes/assets/1172099/99ea821c-94f7-4d89-a412-d6d38a71c9cc)
