### PR TITLE
chore: fix Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
     branches:
       - main
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,7 +4,8 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize]
+
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -14,6 +15,9 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'safe to preview')
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - run: npm install --global vercel@latest
       - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
This PR fixes several issues:
- now, vercel preview uses the correct repo and branch in `actions/checkout@v3` to checkout the code associated to the PR.
- both actions "vercel preview" and "lint" are triggered at PR opening **and** each time the branch associated to the PR is updated (Github event `synchronize`).

To allow anyone accessing the Vercel preview URL, go on vercel.com in the project settings. Go to "Deployment protection" and disable "Vercel Authentication".