### PR TITLE
Improved fullscreen experience

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -38,15 +38,15 @@ import { InstructionsTable } from './InstructionsTable'
 
 type Props = {
   readOnly?: boolean
+  isFullScreen?: boolean
 }
 
 type SCEditorRef = {
   _input: HTMLTextAreaElement
 } & RefObject<React.FC>
 
-const cairoEditorHeight = 350
-
-const Editor = ({ readOnly = false }: Props) => {
+const Editor = ({ readOnly = false, isFullScreen = false }: Props) => {
+  const cairoEditorHeight = isFullScreen ? 650 : 350
   const { settingsLoaded, getSetting } = useContext(SettingsContext)
   const router = useRouter()
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,14 +25,14 @@ const HomePage = () => {
         />
       </Head>
       <AboutCairoVMBanner />
-
       <Container fullWidth={isFullScreen}>
-        <Editor />
+        <Editor isFullScreen={isFullScreen} />
       </Container>
-
-      <section className="pt-20 pb-10 text-center">
-        <ContributeBox />
-      </section>
+      {!isFullScreen && (
+        <section className="pt-20 pb-10 text-center">
+          <ContributeBox />
+        </section>
+      )}
     </>
   )
 }


### PR DESCRIPTION
While entering fullscreen, remove the contributions request from sight. I hardcoded the 650 value, since 350 was hardcoded as well. However, this could be improved again in the future to make use of 100% height from parent html element for example, but this can be merged in the meantime. Addresses #106 and #89