### PR TITLE
:lipstick: make modal pretty on dark mode

### DIFF
--- a/components/Editor/ArgumentsHelperModal.tsx
+++ b/components/Editor/ArgumentsHelperModal.tsx
@@ -15,7 +15,7 @@ export const ArgumentsHelperModal = ({
       visible={showArgumentsHelper}
       setVisible={setShowArgumentsHelper}
     >
-      <div className="text-sm text-gray-900">
+      <div className="text-sm text-gray-900 dark:text-gray-200">
         <p className="my-2">
           This input field accepts a list of program arguments for the{' '}
           <CodeElement>main()</CodeElement> function, separated by a{' '}
@@ -58,7 +58,7 @@ export const ArgumentsHelperModal = ({
 
 const CodeElement = ({ children }: { children: string }) => {
   return (
-    <code className="inline-block px-1.5 py-0.5 my-0.5 rounded bg-stone-200/70 text-red-500">
+    <code className="inline-block px-1.5 py-0.5 my-0.5 rounded bg-stone-200/70 dark:bg-slate-700 text-red-400">
       {children}
     </code>
   )

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -26,7 +26,7 @@ export const Modal = ({
         onKeyDown={closeModal}
       >
         <div
-          className="md:max-w-3xl relative p-4 bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-400 w-full m-auto flex-col flex rounded-lg cursor-auto"
+          className="md:max-w-3xl relative p-4 bg-white dark:bg-gray-800 w-full m-auto flex-col flex rounded-lg cursor-auto"
           role="button"
           tabIndex={0}
           onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
Fixes #113, I didn't find code blocks in evm.codes so I asked AI for recommandations for a good color palette that fit with native tailwind CSS colors. Result seems good to me, feel free to challenge 

Light
<img width="783" alt="image" src="https://github.com/walnuthq/cairovm.codes/assets/1172099/98665eff-1acc-41c0-9b93-40c2f5422aa7">

Dark
<img width="1384" alt="image" src="https://github.com/walnuthq/cairovm.codes/assets/1172099/7130bbe1-12ca-4b58-ae74-8efeaf09a3b2">
