### PR TITLE
fix: compile and runtime error messaging

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -183,12 +183,15 @@ const Editor = ({ readOnly = false }: Props) => {
       if (serializedOutput) {
         addToConsoleLog(`Execution output: ${serializedOutput}`)
       }
+
+      if (executionState === ProgramExecutionState.Error) {
+        addToConsoleLog(
+          'Runtime error: ' + executionPanicMessage,
+          LogType.Error,
+        )
+      }
     } else if (compilationState === ProgramCompilationState.CompilationErr) {
       addToConsoleLog('Compilation failed', LogType.Error)
-    }
-
-    if (executionState === ProgramExecutionState.Error) {
-      addToConsoleLog('Runtime error: ' + executionPanicMessage, LogType.Error)
     }
 
     // Compilation finished, log the API logs, if any

--- a/components/Tracer/index.tsx
+++ b/components/Tracer/index.tsx
@@ -253,7 +253,7 @@ export const Tracer = () => {
             </button>
           </nav>
         </div>
-        <div className="pane pane-light overflow-auto pb-4 grow h-[90%]">
+        <div className="pane pane-light overflow-auto pb-4 grow h-[calc(100%_-_38px)]">
           {selectedConsoleTab === IConsoleTab.Console && <Console />}
 
           {selectedConsoleTab === IConsoleTab.DebugInfo && (

--- a/context/cairoVMApiContext.tsx
+++ b/context/cairoVMApiContext.tsx
@@ -196,6 +196,7 @@ export const CairoVMApiProvider: React.FC<PropsWithChildren> = ({
             ? ProgramCompilationState.CompilationSuccess
             : ProgramCompilationState.CompilationErr,
         )
+        setLogs(data.logs)
         setExecutionState(
           data.is_execution_successful === true
             ? ProgramExecutionState.Success
@@ -211,7 +212,6 @@ export const CairoVMApiProvider: React.FC<PropsWithChildren> = ({
         setSierraCode(data.sierra_program_code)
         setCairoLangCompilerVersion(data.cairo_lang_compiler_version)
         setSerializedOutput(data.serialized_output)
-        setLogs(data.logs)
         setExecutionPanicMessage(data.execution_panic_message)
         setTracerData({
           memory: data.tracer_data.memory,


### PR DESCRIPTION
Resolves #145 

I had to move up `setLogs(data.logs)` to get the logs.

I dont know if this is a known issue but whenever compilation fails, it throws error in the below code segment because `is_execution_successful` & `tracer_data` in `data` is undefined as not returned by the `run` API and it would jump to catch block thus not updating the logs.


![image](https://github.com/walnuthq/cairovm.codes/assets/61868840/e54ddd49-f5cb-4dbb-9f62-8b714bd6dd57)


Also added a small style fix because in some screens console log messages were being cutoff like this 
![image](https://github.com/walnuthq/cairovm.codes/assets/61868840/472e2fdf-d2b2-47af-a249-0e14987c1945)

