### PR TITLE
chore: Improve permalinks - Issue #167

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "highlightjs-cairo": "^0.4.0",
         "kbar": "^0.1.0-beta.45",
         "lodash.debounce": "^4.0.8",
+        "lz-string": "^1.5.0",
         "monaco-editor": "^0.47.0",
         "monaco-editor-core": "^0.47.0",
         "next": "13",
@@ -9249,6 +9250,14 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.23.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "highlightjs-cairo": "^0.4.0",
     "kbar": "^0.1.0-beta.45",
     "lodash.debounce": "^4.0.8",
+    "lz-string": "^1.5.0",
     "monaco-editor": "^0.47.0",
     "monaco-editor-core": "^0.47.0",
     "next": "13",


### PR DESCRIPTION
#167 
The problem was solely related to the telegram application on macbooks downloaded from the App store. The decision took a lot more effort than I expected. In the end, I figured out what the problem was, in this case, telegram very selectively allows you to insert links with base64 encoding, so standard methods like btoa() and encodeURIComponent() will not work here. The LZString library came to the rescue with its compressToEncodedURIComponent method, the encoding of which allows you to correctly insert links both in telegram on windows and in telegram on macbooks.

I also added DebugMode to the links, there was no difficulty with that.