### PR TITLE
Bug: Selecting code examples does not work when navigating to permalink - Issue #169

### DIFF
--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -221,6 +221,7 @@ const Editor = ({ readOnly = false }: Props) => {
         const debugModeValue = query.debugMode as ProgramDebugMode
         setDebugMode(debugModeValue)
       }
+      router.push('/')
     } else {
       const initialCodeType: CodeType =
         getSetting(Setting.EditorCodeType) || CodeType.Cairo


### PR DESCRIPTION
#169
The problem was that the url included some parameters, which made it impossible to select another sample code from select. Now, when you click on permalink, it will immediately disappear from the url, but all the necessary parameters will be saved and you can use select with code examples.