### PR TITLE
Redesign: special handle for cairo-lang - Issue #178

### DIFF
--- a/components/Editor/EditorFooter.tsx
+++ b/components/Editor/EditorFooter.tsx
@@ -8,7 +8,7 @@ import ThemeSelector from '../ThemeSelector'
 import ToggleFullScreen from '../ToggleFullScreen'
 import ToggleThreeColumnLayout from '../ToggleThreeColumnLayout'
 
-function EditorFooter() {
+function EditorFooter({ withoutContent = false }) {
   const { cairoLangCompilerVersion } = useContext(CairoVMApiContext)
   const { isFullScreen } = useContext(AppUiContext)
   return (
@@ -24,7 +24,7 @@ function EditorFooter() {
           : ' '}
       </span>
 
-      {isFullScreen && (
+      {isFullScreen && !withoutContent && (
         <div className="flex items-center justify-end divide-x divide-gray-200 dark:divide-black-500">
           <span className="pr-4">
             Made with ❤️ by{' '}

--- a/components/Editor/Header.tsx
+++ b/components/Editor/Header.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image'
 import cairoLogo from 'public/cairo_logo.png'
 import Select, { OnChangeValue } from 'react-select'
 
+import ToggleThreeColumnLayout from 'components/ToggleThreeColumnLayout'
+
 import { CodeType } from '../../context/appUiContext'
 
 type Props = {
@@ -11,6 +13,7 @@ type Props = {
   onCodeTypeChange: (option: OnChangeValue<any, any>) => void
   onlyDropDown?: boolean
   withLogo?: boolean
+  anotherTitle?: boolean
 }
 
 const codeLangOptions = Object.keys(CodeType).map((lang) => ({
@@ -23,6 +26,7 @@ const EditorHeader = ({
   onCodeTypeChange,
   onlyDropDown = false,
   withLogo = false,
+  anotherTitle = false,
 }: Props) => {
   const codeTypeValue = useMemo(
     () => ({
@@ -34,20 +38,34 @@ const EditorHeader = ({
   return (
     <>
       <div className={'flex justify-between items-center w-full'}>
-        {!onlyDropDown &&
-          (withLogo ? (
-            <div className="flex items-center text-lg font-semibold tracking-tight text-gray-900 dark:text-white">
-              <span className="pr-2">cairovm</span>
-              <Image src={cairoLogo} width={20} height={20} alt="cairo" />
-              <span className="pl-2">codes</span>
-            </div>
-          ) : (
-            <h3 className="font-semibold text-md hidden xl:inline-flex items-center">
-              <span>Cairo VM Playground</span>
-            </h3>
-          ))}
+        <div className="flex items-center">
+          {!onlyDropDown &&
+            (withLogo && !anotherTitle ? (
+              <div className="flex items-center text-lg font-semibold tracking-tight text-gray-900 dark:text-white">
+                <span className="pr-2">cairovm</span>
+                <Image src={cairoLogo} width={20} height={20} alt="cairo" />
+                <span className="pl-2">codes</span>
+              </div>
+            ) : (
+              <div>
+                <h3
+                  className={`${
+                    !anotherTitle && 'font-semibold'
+                  } text-md hidden xl:inline-flex items-center`}
+                >
+                  <span>{!anotherTitle && 'Cairo VM'}Playground</span>
+                </h3>
+                {anotherTitle && (
+                  <div className="text-xs text-[#BDBDBDEE]">
+                    Cairo compiler v2.6.3
+                  </div>
+                )}
+              </div>
+            ))}
+        </div>
 
         <div className="flex items-center ">
+          {anotherTitle && <ToggleThreeColumnLayout />}
           <Select
             className="z-40"
             onChange={onCodeTypeChange}

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -44,6 +44,7 @@ import { InstructionsTable } from './InstructionsTable'
 // @ts-ignore - Cairo is not part of the official highlightjs package
 type Props = {
   readOnly?: boolean
+  isCairoLangPage?: boolean
 }
 
 interface DecorationOptions {
@@ -59,7 +60,7 @@ interface Decoration {
   options: DecorationOptions
 }
 
-const Editor = ({ readOnly = false }: Props) => {
+const Editor = ({ readOnly = false, isCairoLangPage = false }: Props) => {
   const { settingsLoaded, getSetting } = useContext(SettingsContext)
   const router = useRouter()
 
@@ -436,6 +437,7 @@ const Editor = ({ readOnly = false }: Props) => {
                     codeType={codeType}
                     onCodeTypeChange={({ value }) => setCodeType(value)}
                     withLogo={isFullScreen}
+                    anotherTitle={isCairoLangPage}
                   />
                 </div>
 
@@ -539,7 +541,7 @@ const Editor = ({ readOnly = false }: Props) => {
           </div>
         </div>
 
-        <EditorFooter />
+        <EditorFooter withoutContent={isCairoLangPage} />
       </div>
       <ArgumentsHelperModal
         showArgumentsHelper={showArgumentsHelper}

--- a/context/appUiContext.tsx
+++ b/context/appUiContext.tsx
@@ -24,6 +24,7 @@ type AppUiContextProps = {
   toggleThreeColumnLayout: () => void
   toggleFullScreen: () => void
   addToConsoleLog: (line: string, type?: LogType) => void
+  enableFullScreen: () => void
 }
 
 export const AppUiContext = createContext<AppUiContextProps>({
@@ -33,6 +34,7 @@ export const AppUiContext = createContext<AppUiContextProps>({
   toggleThreeColumnLayout: () => undefined,
   toggleFullScreen: () => undefined,
   addToConsoleLog: () => undefined,
+  enableFullScreen: () => undefined,
 })
 
 export const AppUiProvider: React.FC<PropsWithChildren> = ({ children }) => {
@@ -47,6 +49,10 @@ export const AppUiProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   const toggleFullScreen = () => {
     setIsFullScreen(!isFullScreen)
+  }
+
+  const enableFullScreen = () => {
+    setIsFullScreen(true)
   }
 
   const toggleThreeColumnLayout = () => {
@@ -70,6 +76,7 @@ export const AppUiProvider: React.FC<PropsWithChildren> = ({ children }) => {
         toggleThreeColumnLayout,
         toggleFullScreen,
         addToConsoleLog,
+        enableFullScreen,
       }}
     >
       {children}

--- a/pages/cairo-lang/index.tsx
+++ b/pages/cairo-lang/index.tsx
@@ -1,0 +1,31 @@
+import { useContext, useEffect } from 'react'
+
+import Head from 'next/head'
+
+import { AppUiContext } from 'context/appUiContext'
+
+import Editor from 'components/Editor'
+
+const HomePage = () => {
+  const { enableFullScreen } = useContext(AppUiContext)
+
+  useEffect(() => {
+    enableFullScreen()
+  }, [enableFullScreen])
+
+  return (
+    <>
+      <Head>
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="EVM Codes - Opcodes" />
+        <meta
+          name="description"
+          content="An Ethereum Virtual Machine Opcodes Interactive Reference"
+        />
+      </Head>
+      <Editor isCairoLangPage={true} />
+    </>
+  )
+}
+
+export default HomePage

--- a/pages/cairo-lang/index.tsx
+++ b/pages/cairo-lang/index.tsx
@@ -6,7 +6,7 @@ import { AppUiContext } from 'context/appUiContext'
 
 import Editor from 'components/Editor'
 
-const HomePage = () => {
+const CairoLangPage = () => {
   const { enableFullScreen } = useContext(AppUiContext)
 
   useEffect(() => {
@@ -28,4 +28,4 @@ const HomePage = () => {
   )
 }
 
-export default HomePage
+export default CairoLangPage


### PR DESCRIPTION
The cairo-lang page has been added, where it is impossible to exit full-screen mode, the k-bar button has been removed and the necessary changes have been made in accordance with Figma